### PR TITLE
fix: 修复 dns_cf.yml 中 run 步骤的 YAML 缩进错误

### DIFF
--- a/.github/workflows/dns_cf.yml
+++ b/.github/workflows/dns_cf.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: 'Set up Python'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.12
       - name: 'Install dependencies'
@@ -22,4 +22,4 @@ jobs:
           CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
           CF_DNS_NAME: ${{ secrets.CF_DNS_NAME }}
           PUSHPLUS_TOKEN: ${{ secrets.PUSHPLUS_TOKEN }}
-            run: python dnscf.py
+        run: python dnscf.py


### PR DESCRIPTION
## 问题\n\n`dns_cf.yml` 中 `run: python dnscf.py` 被错误地缩进在 `env:` 块内部，导致 YAML 解析时将其作为环境变量键值对而非步骤字段，**`dnscf.py` 脚本实际从未被执行**。\n\n## 变更内容\n\n- **`.github/workflows/dns_cf.yml`**：\n  - 将 `run: python dnscf.py` 调整到与 `env:` 同级（步骤级别），修复 YAML 结构\n  - 将 `actions/checkout` 从 v3 升级到 v4\n  - 将 `actions/setup-python` 从 v4 升级到 v5\n\n## 对比\n\n修复前（`run` 被错误地缩进在 `env` 内，实为无效 YAML 键）：\n```yaml\n      - name: 'run dnscf'\n        env:\n          CF_API_TOKEN: ...\n          PUSHPLUS_TOKEN: ...\n            run: python dnscf.py   # ← 错误缩进，从未执行\n```\n\n修复后：\n```yaml\n      - name: 'run dnscf'\n        env:\n          CF_API_TOKEN: ...\n          PUSHPLUS_TOKEN: ...\n        run: python dnscf.py       # ← 正确，步骤级字段\n```\n\n## 测试计划\n\n- [ ] 手动触发 `dns_cf_push` workflow，确认 `dnscf.py` 被正常执行\n- [ ] 检查 Cloudflare DNS 记录已更新"

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7yNnaVUrQCx87367NT6ME)_