### PR TITLE
Add Claude Code skills (setup-actions, update-dns)

### DIFF
--- a/.claude/skills/setup-actions.md
+++ b/.claude/skills/setup-actions.md
@@ -1,0 +1,30 @@
+---
+name: setup-actions
+description: Guide the user through configuring GitHub Actions secrets for cf-speed-dns to enable automatic Cloudflare IP selection and DNS push.
+---
+
+Help the user configure the required GitHub Actions secrets for cf-speed-dns.
+
+**For DNSPod (Tencent Cloud DNS) push (`dnspod.py`):**
+
+Required secrets to add under *Settings → Secrets and variables → Actions*:
+- `DOMAIN` — root domain, e.g. `example.com`
+- `SUB_DOMAIN` — subdomain prefix, e.g. `cdn`
+- `SECRETID` — Tencent Cloud API SecretId
+- `SECRETKEY` — Tencent Cloud API SecretKey
+- `PUSHPLUS_TOKEN` — PushPlus notification token (from https://www.pushplus.plus)
+
+**For Cloudflare DNS push (`dnscf.py`):**
+
+Required secrets:
+- `CF_API_TOKEN` — Cloudflare API token with DNS edit permission
+- `CF_ZONE_ID` — Zone ID from the Cloudflare dashboard
+- `CF_DNS_NAME` — Full DNS record name, e.g. `cdn.example.com`
+- `PUSHPLUS_TOKEN` — PushPlus notification token
+
+**Verification steps:**
+1. Trigger the workflow manually via *Actions → Run workflow*.
+2. Check the workflow run log for "success" lines with the updated IPs.
+3. Verify the DNS record has been updated in DNSPod/Cloudflare dashboard.
+
+The workflow fetches the top optimal IPs from `https://ip.164746.xyz/ipTop.html` and updates each matching DNS A record.

--- a/.claude/skills/update-dns.md
+++ b/.claude/skills/update-dns.md
@@ -1,0 +1,39 @@
+---
+name: update-dns
+description: Manually run the Cloudflare optimal IP selection and push the results to DNSPod or Cloudflare DNS.
+---
+
+Run the DNS update scripts locally or review the last GitHub Actions run.
+
+**Run locally (requires environment variables):**
+
+For DNSPod:
+```bash
+export DOMAIN=example.com
+export SUB_DOMAIN=cdn
+export SECRETID=your_secret_id
+export SECRETKEY=your_secret_key
+export PUSHPLUS_TOKEN=your_token
+pip install -r requirements.txt
+python3 dnspod.py
+```
+
+For Cloudflare DNS:
+```bash
+export CF_API_TOKEN=your_token
+export CF_ZONE_ID=your_zone_id
+export CF_DNS_NAME=cdn.example.com
+export PUSHPLUS_TOKEN=your_token
+pip install -r requirements.txt
+python3 dnscf.py
+```
+
+**What the scripts do:**
+1. Fetch the current top optimal Cloudflare IPs from `https://ip.164746.xyz/ipTop.html` (comma-separated list).
+2. Read existing DNS A records for the configured domain.
+3. Update each record with the new optimal IP in order.
+4. Send a WeChat push notification via PushPlus with the update results.
+
+**Troubleshooting:**
+- If the IP fetch fails after 5 retries, check connectivity to `ip.164746.xyz`.
+- If DNS update fails, verify API credentials and that the record count matches the number of IPs returned.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: cf-speed-dns
+description: Work with cf-speed-dns — a GitHub Actions project that fetches optimal Cloudflare IPs every 5 minutes and pushes them to DNSPod or Cloudflare DNS. Use when configuring secrets, running scripts locally, or debugging DNS update failures.
+---
+
+# cf-speed-dns
+
+A GitHub Actions project that automatically selects the fastest Cloudflare IPs and updates DNS records via Tencent DNSPod (`dnspod.py`) or Cloudflare DNS API (`dnscf.py`), with WeChat push notifications via PushPlus.
+
+## When to use
+
+Use this skill when setting up the project, configuring GitHub Actions secrets, running the update scripts locally, or debugging DNS sync failures.
+
+## Instructions
+
+### Setting up GitHub Actions
+
+Add these secrets under *Settings → Secrets and variables → Actions*:
+
+**For DNSPod (`dnspod.py`):**
+- `DOMAIN` — root domain, e.g. `example.com`
+- `SUB_DOMAIN` — subdomain prefix, e.g. `cdn`
+- `SECRETID` — Tencent Cloud API SecretId
+- `SECRETKEY` — Tencent Cloud API SecretKey
+- `PUSHPLUS_TOKEN` — PushPlus token from https://www.pushplus.plus
+
+**For Cloudflare DNS (`dnscf.py`):**
+- `CF_API_TOKEN` — Cloudflare API token with DNS edit permission
+- `CF_ZONE_ID` — Zone ID from the Cloudflare dashboard
+- `CF_DNS_NAME` — full record name, e.g. `cdn.example.com`
+- `PUSHPLUS_TOKEN` — PushPlus token
+
+### Running locally
+
+```bash
+pip install -r requirements.txt
+
+# DNSPod
+DOMAIN=example.com SUB_DOMAIN=cdn SECRETID=xx SECRETKEY=xx PUSHPLUS_TOKEN=xx python3 dnspod.py
+
+# Cloudflare DNS
+CF_API_TOKEN=xx CF_ZONE_ID=xx CF_DNS_NAME=cdn.example.com PUSHPLUS_TOKEN=xx python3 dnscf.py
+```
+
+### How it works
+
+1. Fetches top optimal IPs from `https://ip.164746.xyz/ipTop.html` (comma-separated, up to 5 retries).
+2. Reads existing A records for the configured domain.
+3. Updates each record in order with the new IPs.
+4. Sends a WeChat notification via PushPlus with the results.
+
+### Debugging
+
+- IP fetch failing: check connectivity to `ip.164746.xyz`; the endpoint returns a plain comma-separated string.
+- DNS update failing: verify API credentials are correct and the number of existing DNS records matches the number of IPs returned.
+- Record count mismatch: `dnspod.py` uses list index access — if the API returns fewer records than IPs, it will raise an `IndexError`.


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/setup-actions.md` — guides configuring GitHub Actions secrets for both DNSPod and Cloudflare DNS push
- Adds `.claude/skills/update-dns.md` — shows how to run `dnspod.py` / `dnscf.py` locally with required env vars, and explains what each script does

After merging, users can install these skills with:
```
npx skills add george5402/cf-speed-dns
```

## Test plan

- [ ] Run `npx skills add george5402/cf-speed-dns` and confirm both `setup-actions` and `update-dns` skills are installed
- [ ] Invoke `/setup-actions` in a Claude Code session and verify the secrets guidance is accurate
- [ ] Invoke `/update-dns` and verify the local run instructions are correct

https://claude.ai/code/session_01Ls2y2GJKyzKVi9iz7zP6JA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ls2y2GJKyzKVi9iz7zP6JA)_